### PR TITLE
Bootstrap Next.js scaffold from DESIGN.md

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["next", "next/core-web-vitals"],
+  "rules": {
+    "@next/next/no-img-element": "off"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Node.js
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.next
+out
+.DS_Store
+.env.local
+.env.*
+.vercel
+coverage

--- a/README.md
+++ b/README.md
@@ -90,3 +90,40 @@
 ---
 
 该项目文档反映了前期可行性评估的结论：技术实现简单，但可靠数据稀缺，需要以历史与公开信息汇总为核心方向推进。
+
+## 9. Development Setup
+
+The repository now includes an initial Next.js 14 App Router implementation inspired by `DESIGN.md`. The scaffold focuses on
+rendering curated carrier events with transparent sourcing while keeping the front-end decoupled from future Supabase
+ingestion pipelines.
+
+### Requirements
+
+- Node.js 18+
+- npm (or pnpm/yarn) for dependency management
+
+### Install & Run
+
+```bash
+npm install
+npm run dev
+```
+
+### Available Scripts
+
+- `npm run dev` – Launches the Next.js development server.
+- `npm run build` – Creates an optimized production build.
+- `npm run start` – Serves the production build.
+- `npm run lint` – Executes ESLint using the Next.js configuration.
+- `npm run typecheck` – Runs TypeScript in no-emit mode to validate the schema and API typings.
+
+### Project Structure Highlights
+
+- `app/` – App Router pages including the dashboard, methodology, about, and data explorer views.
+- `app/api/` – Read-only API routes (`/api/vessels`, `/api/events`, `/api/events/[id]`, `/api/stats`) backed by mocked data and
+  validated with Zod schemas.
+- `components/` – Reusable UI primitives (map placeholder, timeline, tables, metric cards, etc.).
+- `lib/` – Domain types, Zod schemas, and in-memory datasets that approximate the future Supabase models.
+
+Future work includes wiring the mocked datasets to live Supabase tables, integrating Mapbox/Leaflet for geospatial
+visualization, and extending automated ingestion scripts.

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,30 @@
+export default function AboutPage() {
+  return (
+    <article className="prose prose-invert max-w-3xl">
+      <h1>About the Project</h1>
+      <p>
+        OSINT Carrier Tracker is a volunteer-led initiative that documents the last publicly verified positions of U.S. Navy
+        aircraft carriers. The project blends open-source research with structured data modeling to help journalists,
+        researchers, and defense observers contextualize carrier deployments.
+      </p>
+      <h2>Team Principles</h2>
+      <ul>
+        <li>
+          <strong>Legal compliance:</strong> We only use information that is already public and honor the terms of service for
+          each source.
+        </li>
+        <li>
+          <strong>Safety aware:</strong> Location data is delayed or obfuscated to protect operational security.
+        </li>
+        <li>
+          <strong>Documented decisions:</strong> Analysts capture review notes and confidence changes for every entry.
+        </li>
+      </ul>
+      <h2>Contact</h2>
+      <p>
+        We are exploring partnerships with media outlets and OSINT communities. For inquiries or to request data access, email
+        <a href="mailto:team@osintcarriertracker.org"> team@osintcarriertracker.org</a>.
+      </p>
+    </article>
+  );
+}

--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { events } from "@/lib/data/events";
+import { reviewLogs } from "@/lib/data/review-logs";
+import { eventSchema, reviewLogSchema } from "@/lib/schema";
+
+export async function GET(_request: NextRequest, { params }: { params: { id: string } }) {
+  const event = events.find((item) => item.id === params.id);
+  if (!event) {
+    return NextResponse.json({ error: "Event not found" }, { status: 404 });
+  }
+
+  const parsedEvent = eventSchema.safeParse(event);
+  if (!parsedEvent.success) {
+    return NextResponse.json({ error: "Event schema invalid", details: parsedEvent.error.format() }, { status: 500 });
+  }
+
+  const logs = reviewLogs.filter((log) => log.eventId === event.id);
+  const parsedLogs = reviewLogSchema.array().safeParse(logs);
+  if (!parsedLogs.success) {
+    return NextResponse.json({ error: "Review logs invalid", details: parsedLogs.error.format() }, { status: 500 });
+  }
+
+  return NextResponse.json({ data: parsedEvent.data, reviewLogs: parsedLogs.data });
+}

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { events } from "@/lib/data/events";
+import { eventSchema } from "@/lib/schema";
+import { ConfidenceLevel } from "@/lib/types";
+
+function filterByConfidence(value: string | null): ConfidenceLevel | undefined {
+  if (!value) return undefined;
+  if (value === "High" || value === "Medium" || value === "Low") {
+    return value;
+  }
+  return undefined;
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const vesselId = searchParams.get("vessel");
+  const startDate = searchParams.get("start_date");
+  const endDate = searchParams.get("end_date");
+  const confidence = filterByConfidence(searchParams.get("confidence"));
+
+  const filtered = events.filter((event) => {
+    if (vesselId && event.vesselId !== vesselId) {
+      return false;
+    }
+    if (confidence && event.confidence !== confidence) {
+      return false;
+    }
+    const start = startDate ? new Date(startDate) : undefined;
+    const end = endDate ? new Date(endDate) : undefined;
+    const eventStart = new Date(event.eventDate.start);
+    if (start && eventStart < start) {
+      return false;
+    }
+    if (end) {
+      const eventEnd = event.eventDate.end ? new Date(event.eventDate.end) : eventStart;
+      if (eventEnd > end) {
+        return false;
+      }
+    }
+    return true;
+  });
+
+  const parsed = eventSchema.array().safeParse(filtered);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Event dataset invalid", details: parsed.error.format() }, { status: 500 });
+  }
+
+  return NextResponse.json({ data: parsed.data, count: parsed.data.length });
+}

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import { fleetStats } from "@/lib/data/stats";
+import { statsSchema } from "@/lib/schema";
+
+export async function GET() {
+  const parsed = statsSchema.safeParse(fleetStats);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Statistics invalid", details: parsed.error.format() }, { status: 500 });
+  }
+
+  return NextResponse.json({ data: parsed.data });
+}

--- a/app/api/vessels/route.ts
+++ b/app/api/vessels/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import { vessels } from "@/lib/data/vessels";
+import { vesselSchema } from "@/lib/schema";
+
+export async function GET() {
+  const parsed = vesselSchema.array().safeParse(vessels);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Vessel dataset invalid", details: parsed.error.format() }, { status: 500 });
+  }
+
+  return NextResponse.json({ data: parsed.data, count: parsed.data.length });
+}

--- a/app/data/page.tsx
+++ b/app/data/page.tsx
@@ -1,0 +1,21 @@
+import { EventTable } from "@/components/event-table";
+import { events } from "@/lib/data/events";
+import { vessels } from "@/lib/data/vessels";
+
+export default function DataPage() {
+  return (
+    <div className="space-y-8">
+      <section className="rounded-xl border border-slate-800 bg-slate-950/70 p-6">
+        <h1 className="text-2xl font-semibold text-white">Structured Data Explorer</h1>
+        <p className="mt-2 text-sm text-slate-300">
+          Filterable tables and future CSV/GeoJSON export endpoints will live here. Data is curated from public reporting,
+          enriched with analyst annotations, and validated during build using schema checks.
+        </p>
+        <div className="mt-4 rounded border border-slate-800 bg-slate-900/50 p-4 text-xs text-slate-400">
+          CSV &amp; GeoJSON download links will be exposed after the automated ingestion pipeline is connected to Supabase.
+        </div>
+      </section>
+      <EventTable events={events} vessels={vessels} />
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,19 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  @apply bg-slate-950 text-slate-100 antialiased;
+}
+
+a {
+  @apply text-navy-300 hover:text-navy-200 underline;
+}
+
+main {
+  @apply min-h-screen bg-slate-950;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,72 @@
+import type { Metadata } from "next";
+import { Inter, PT_Serif } from "next/font/google";
+import Link from "next/link";
+import "./globals.css";
+
+const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
+const serif = PT_Serif({ subsets: ["latin"], weight: ["400", "700"], variable: "--font-serif" });
+
+export const metadata: Metadata = {
+  title: {
+    default: "OSINT Carrier Tracker",
+    template: "%s | OSINT Carrier Tracker",
+  },
+  description:
+    "An open intelligence portal that visualizes the last known positions of U.S. Navy aircraft carriers.",
+  metadataBase: new URL("https://example.com"),
+  openGraph: {
+    title: "OSINT Carrier Tracker",
+    description:
+      "Visualizing the last known positions of U.S. Navy aircraft carriers with transparent sourcing and confidence levels.",
+    type: "website",
+  },
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en" className={`${inter.variable} ${serif.variable}`} suppressHydrationWarning>
+      <body className="min-h-screen bg-slate-950 text-slate-100">
+        <div className="mx-auto flex min-h-screen max-w-6xl flex-col px-6 pb-12">
+          <header className="sticky top-0 z-50 bg-slate-950/80 py-6 backdrop-blur">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <Link href="/" className="font-semibold uppercase tracking-widest text-navy-200">
+                  OSINT Carrier Tracker
+                </Link>
+                <p className="max-w-2xl text-sm text-slate-400">
+                  Visualizing the last publicly verifiable locations of U.S. Navy aircraft carriers. Data is delayed, curated
+                  from open sources, and includes confidence assessments.
+                </p>
+              </div>
+              <nav className="flex items-center gap-4 text-sm text-slate-300">
+                <Link href="/data" className="hover:text-white">
+                  Data Explorer
+                </Link>
+                <Link href="/methodology" className="hover:text-white">
+                  Methodology
+                </Link>
+                <Link href="/about" className="hover:text-white">
+                  About
+                </Link>
+              </nav>
+            </div>
+          </header>
+          <main className="flex-1 py-8">{children}</main>
+          <footer className="border-t border-slate-800 pt-6 text-xs text-slate-500">
+            <p>
+              Information is sourced from publicly available materials and does not represent official U.S. Navy positions.
+              Coordinates are approximate and may be delayed for operational security.
+            </p>
+            <p className="mt-2">
+              &copy; {new Date().getFullYear()} OSINT Carrier Tracker. Built with transparency and ethical OSINT practices.
+            </p>
+          </footer>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/app/methodology/page.tsx
+++ b/app/methodology/page.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+
+export default function MethodologyPage() {
+  return (
+    <article className="prose prose-invert max-w-3xl">
+      <h1>Methodology &amp; Safeguards</h1>
+      <p>
+        OSINT Carrier Tracker is designed as a delayed-intelligence portal. We prioritize transparency, ethical sourcing, and
+        operational security over real-time reporting. The workflow combines automated ingestion with human oversight to
+        maintain verifiable records.
+      </p>
+      <h2>Collection Pipeline</h2>
+      <ol>
+        <li>
+          <strong>Signal ingestion:</strong> RSS feeds, official press releases, social media monitoring, and maritime analytics
+          provide candidate stories.
+        </li>
+        <li>
+          <strong>AI triage:</strong> Language models extract vessel names, timestamps, and geolocations into a structured draft.
+        </li>
+        <li>
+          <strong>Human review:</strong> Editors verify provenance, confidence, and geospatial plausibility before approval.
+        </li>
+      </ol>
+      <h2>Confidence Ratings</h2>
+      <p>
+        Confidence scores communicate how well-corroborated an event is. “High” entries originate from official statements or
+        multi-source confirmation. “Medium” entries typically rely on reputable media or photographic evidence. “Low” denotes
+        speculative or single-source OSINT that still merits tracking.
+      </p>
+      <h2>Delay &amp; Obfuscation</h2>
+      <p>
+        To avoid operational risk, coordinates are generalized to 0.1°–1° and may be withheld entirely when sensitive. Events
+        older than 14 days trigger an automatic “position unknown” reminder for analyst follow-up.
+      </p>
+      <p>
+        Interested in contributing vetted leads? Contact the maintainers via the <Link href="/about">about page</Link> to join
+        the closed beta of the reviewer workflow.
+      </p>
+    </article>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,33 @@
+import { Dashboard } from "@/components/dashboard";
+import { events } from "@/lib/data/events";
+import { fleetStats } from "@/lib/data/stats";
+import { vessels } from "@/lib/data/vessels";
+
+export default function HomePage() {
+  return (
+    <div className="space-y-12">
+      <section className="rounded-xl border border-slate-800 bg-gradient-to-br from-navy-900/40 via-slate-950 to-slate-950 p-8">
+        <h1 className="text-3xl font-semibold text-white sm:text-4xl">U.S. Carrier Deployments at a Glance</h1>
+        <p className="mt-4 max-w-3xl text-base text-slate-300">
+          OSINT Carrier Tracker consolidates publicly verifiable reporting on U.S. Navy aircraft carriers. Each position is
+          timestamped, graded for confidence, and linked to the original source so analysts can trace the intel pipeline.
+        </p>
+        <div className="mt-6 grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          <div className="rounded-lg border border-navy-800/50 bg-navy-900/30 p-4 text-sm text-slate-200">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-navy-200">Transparency First</h2>
+            <p className="mt-2 text-slate-300">Every event includes primary sourcing, analyst notes, and review history.</p>
+          </div>
+          <div className="rounded-lg border border-navy-800/50 bg-navy-900/30 p-4 text-sm text-slate-200">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-navy-200">Confidence Ratings</h2>
+            <p className="mt-2 text-slate-300">OSINT is uncertain—confidence scores highlight corroborated vs. speculative reports.</p>
+          </div>
+          <div className="rounded-lg border border-navy-800/50 bg-navy-900/30 p-4 text-sm text-slate-200">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-navy-200">Ethical OSINT</h2>
+            <p className="mt-2 text-slate-300">Positions are delayed and generalized to protect operations and comply with policy.</p>
+          </div>
+        </div>
+      </section>
+      <Dashboard vessels={vessels} events={events} stats={fleetStats} />
+    </div>
+  );
+}

--- a/components/confidence-badge.tsx
+++ b/components/confidence-badge.tsx
@@ -1,0 +1,19 @@
+import { ConfidenceLevel } from "@/lib/types";
+
+const COLOR_MAP: Record<ConfidenceLevel, string> = {
+  High: "bg-emerald-500/20 text-emerald-300 border-emerald-500/60",
+  Medium: "bg-amber-500/20 text-amber-200 border-amber-500/60",
+  Low: "bg-rose-500/20 text-rose-200 border-rose-500/60",
+};
+
+interface ConfidenceBadgeProps {
+  level: ConfidenceLevel;
+}
+
+export function ConfidenceBadge({ level }: ConfidenceBadgeProps) {
+  return (
+    <span className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-semibold ${COLOR_MAP[level]}`}>
+      {level} confidence
+    </span>
+  );
+}

--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { EventRecord, FleetStatistics, Vessel, ConfidenceLevel } from "@/lib/types";
+import { MapPanel } from "./map-panel";
+import { EventTimeline } from "./event-timeline";
+import { MetricCard } from "./metric-card";
+import { getVesselEvents } from "@/lib/utils";
+
+interface DashboardProps {
+  vessels: Vessel[];
+  events: EventRecord[];
+  stats: FleetStatistics;
+}
+
+const confidenceOptions: (ConfidenceLevel | "All")[] = ["All", "High", "Medium", "Low"];
+
+export function Dashboard({ vessels, events, stats }: DashboardProps) {
+  const [selectedVesselId, setSelectedVesselId] = useState<string | "All">("All");
+  const [selectedConfidence, setSelectedConfidence] = useState<ConfidenceLevel | "All">("All");
+
+  const filteredEvents = useMemo(() => {
+    const vesselFiltered = getVesselEvents(events, selectedVesselId === "All" ? undefined : selectedVesselId);
+    if (selectedConfidence === "All") {
+      return vesselFiltered;
+    }
+    return vesselFiltered.filter((event) => event.confidence === selectedConfidence);
+  }, [events, selectedConfidence, selectedVesselId]);
+
+  const sortedEvents = useMemo(
+    () =>
+      [...filteredEvents].sort(
+        (a, b) => new Date(b.lastVerifiedAt).getTime() - new Date(a.lastVerifiedAt).getTime(),
+      ),
+    [filteredEvents],
+  );
+
+  return (
+    <div className="space-y-10">
+      <section className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <MetricCard title="Carriers tracked" value={stats.totalVessels} description="Active vessels in watchlist" />
+        <MetricCard
+          title="Recent updates"
+          value={stats.eventsLast30Days}
+          description="Events verified during the last 30 days"
+        />
+        <MetricCard
+          title="Deployments underway"
+          value={stats.activeDeployments}
+          description="Carriers currently reported at sea"
+        />
+        <MetricCard
+          title="Needs review"
+          value={stats.vesselsMissingUpdates}
+          description="Vessels with aging intelligence (>14 days)"
+        />
+      </section>
+
+      <section className="rounded-xl border border-slate-800 bg-slate-950/80 p-6">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-white">Filter intelligence feed</h2>
+            <p className="mt-1 text-sm text-slate-400">
+              Narrow events by hull or confidence rating to review recent movements and sourcing quality.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-4 text-sm text-slate-300">
+            <label className="flex flex-col gap-2">
+              <span className="text-xs uppercase tracking-wide text-slate-500">Vessel</span>
+              <select
+                className="rounded border border-slate-700 bg-slate-900 px-3 py-2"
+                value={selectedVesselId}
+                onChange={(event) => setSelectedVesselId(event.target.value)}
+              >
+                <option value="All">All vessels</option>
+                {vessels.map((vessel) => (
+                  <option key={vessel.id} value={vessel.id}>
+                    {vessel.name} ({vessel.hullNumber})
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex flex-col gap-2">
+              <span className="text-xs uppercase tracking-wide text-slate-500">Confidence</span>
+              <select
+                className="rounded border border-slate-700 bg-slate-900 px-3 py-2"
+                value={selectedConfidence}
+                onChange={(event) => setSelectedConfidence(event.target.value as ConfidenceLevel | "All")}
+              >
+                {confidenceOptions.map((option) => (
+                  <option key={option} value={option}>
+                    {option}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+        </div>
+      </section>
+
+      <MapPanel
+        vessels={vessels}
+        events={sortedEvents}
+        selectedVesselId={selectedVesselId === "All" ? undefined : selectedVesselId}
+      />
+
+      <EventTimeline events={sortedEvents} vessels={vessels} />
+    </div>
+  );
+}

--- a/components/event-table.tsx
+++ b/components/event-table.tsx
@@ -1,0 +1,55 @@
+import { EventRecord, Vessel } from "@/lib/types";
+import { ConfidenceBadge } from "./confidence-badge";
+import { formatDateRange } from "@/lib/utils";
+
+interface EventTableProps {
+  events: EventRecord[];
+  vessels: Vessel[];
+}
+
+export function EventTable({ events, vessels }: EventTableProps) {
+  const vesselLookup = new Map(vessels.map((vessel) => [vessel.id, vessel]));
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-slate-800 text-left text-sm text-slate-300">
+        <thead className="bg-slate-900/60 text-xs uppercase tracking-wide text-slate-400">
+          <tr>
+            <th className="px-4 py-3">Vessel</th>
+            <th className="px-4 py-3">Date</th>
+            <th className="px-4 py-3">Location</th>
+            <th className="px-4 py-3">Confidence</th>
+            <th className="px-4 py-3">Evidence</th>
+            <th className="px-4 py-3">Source</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-800">
+          {events.map((event) => {
+            const vessel = vesselLookup.get(event.vesselId);
+            return (
+              <tr key={event.id} className="hover:bg-slate-900/50">
+                <td className="px-4 py-3 text-white">
+                  <div className="flex flex-col">
+                    <span className="font-medium">{vessel?.name ?? "Unknown"}</span>
+                    <span className="text-xs text-slate-500">{vessel?.hullNumber ?? "--"}</span>
+                  </div>
+                </td>
+                <td className="px-4 py-3 text-xs text-slate-400">{formatDateRange(event)}</td>
+                <td className="px-4 py-3">{event.location.locationName}</td>
+                <td className="px-4 py-3">
+                  <ConfidenceBadge level={event.confidence} />
+                </td>
+                <td className="px-4 py-3 text-xs text-slate-400">{event.evidenceType}</td>
+                <td className="px-4 py-3 text-xs">
+                  <a href={event.sourceUrl} className="text-navy-200 hover:text-navy-100" target="_blank" rel="noreferrer">
+                    Source ↗
+                  </a>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/components/event-timeline.tsx
+++ b/components/event-timeline.tsx
@@ -1,0 +1,52 @@
+import { EventRecord, Vessel } from "@/lib/types";
+import { ConfidenceBadge } from "./confidence-badge";
+import { formatDateRange } from "@/lib/utils";
+
+interface EventTimelineProps {
+  events: EventRecord[];
+  vessels: Vessel[];
+}
+
+export function EventTimeline({ events, vessels }: EventTimelineProps) {
+  return (
+    <section className="rounded-xl border border-slate-800 bg-slate-950/80 p-6">
+      <header className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-white">Event Timeline</h2>
+          <p className="mt-1 text-sm text-slate-400">
+            Sorted chronologically with the newest verified events first. Click through to review sourcing details before
+            publication.
+          </p>
+        </div>
+      </header>
+      <ol className="mt-6 space-y-5">
+        {events.map((event) => {
+          const vessel = vessels.find((v) => v.id === event.vesselId);
+          return (
+            <li key={event.id} className="grid gap-2 rounded-lg border border-slate-800 bg-slate-900/40 p-4 shadow-sm">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <p className="text-sm font-semibold text-white">
+                    {vessel?.name ?? "Unknown Vessel"}
+                    <span className="ml-2 text-xs uppercase tracking-wide text-slate-500">{vessel?.hullNumber}</span>
+                  </p>
+                  <p className="text-xs text-slate-400">{formatDateRange(event)}</p>
+                </div>
+                <ConfidenceBadge level={event.confidence} />
+              </div>
+              <p className="text-sm text-slate-300">{event.summary}</p>
+              <div className="flex flex-wrap items-center gap-3 text-xs text-slate-400">
+                <span>Location: {event.location.locationName}</span>
+                <span>Evidence: {event.evidenceType}</span>
+                <span>Last verified: {new Date(event.lastVerifiedAt).toLocaleString()}</span>
+                <a href={event.sourceUrl} className="text-navy-200 hover:text-navy-100" target="_blank" rel="noreferrer">
+                  Source ↗
+                </a>
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+}

--- a/components/map-panel.tsx
+++ b/components/map-panel.tsx
@@ -1,0 +1,71 @@
+import { EventRecord, Vessel } from "@/lib/types";
+import { ConfidenceBadge } from "./confidence-badge";
+import { formatDateRange, getLatestEventsByVessel } from "@/lib/utils";
+
+interface MapPanelProps {
+  vessels: Vessel[];
+  events: EventRecord[];
+  selectedVesselId?: string;
+}
+
+export function MapPanel({ vessels, events, selectedVesselId }: MapPanelProps) {
+  const latestByVessel = getLatestEventsByVessel(events);
+  const displayVessels = selectedVesselId ? vessels.filter((v) => v.id === selectedVesselId) : vessels;
+
+  return (
+    <section className="rounded-xl border border-slate-800 bg-gradient-to-br from-slate-900/80 via-slate-900/60 to-slate-950 p-6">
+      <div className="flex items-start justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-white">Last Known Positions</h2>
+          <p className="mt-1 text-sm text-slate-400">
+            Interactive map placeholder. Integrate Mapbox GL JS or React Leaflet to visualize live vessel markers in future
+            iterations.
+          </p>
+        </div>
+        <div className="rounded border border-slate-800 bg-slate-900 px-3 py-1 text-xs text-slate-400">
+          Map Integration Planned
+        </div>
+      </div>
+      <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {displayVessels.map((vessel) => {
+          const latest = latestByVessel[vessel.id];
+          if (!latest) {
+            return (
+              <article
+                key={vessel.id}
+                className="rounded-lg border border-slate-800 bg-slate-900/50 p-4 text-sm text-slate-400"
+              >
+                <h3 className="text-base font-semibold text-white">{vessel.name}</h3>
+                <p className="text-xs uppercase tracking-wide text-slate-500">{vessel.hullNumber}</p>
+                <p className="mt-3 text-slate-500">No verified events yet.</p>
+              </article>
+            );
+          }
+
+          return (
+            <article key={vessel.id} className="rounded-lg border border-slate-800 bg-slate-900/50 p-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <h3 className="text-base font-semibold text-white">{vessel.name}</h3>
+                  <p className="text-xs uppercase tracking-wide text-slate-500">{vessel.hullNumber}</p>
+                </div>
+                <ConfidenceBadge level={latest.confidence} />
+              </div>
+              <p className="mt-3 text-sm text-slate-300">{latest.location.locationName}</p>
+              <p className="mt-1 text-xs text-slate-500">{formatDateRange(latest)}</p>
+              <p className="mt-3 text-xs text-slate-400">{latest.summary}</p>
+              <a
+                href={latest.sourceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-3 inline-block text-xs text-navy-200 hover:text-navy-100"
+              >
+                View source ↗
+              </a>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/components/metric-card.tsx
+++ b/components/metric-card.tsx
@@ -1,0 +1,15 @@
+interface MetricCardProps {
+  title: string;
+  value: string | number;
+  description: string;
+}
+
+export function MetricCard({ title, value, description }: MetricCardProps) {
+  return (
+    <div className="rounded-lg border border-slate-800 bg-slate-900/40 p-4 shadow-lg">
+      <p className="text-xs uppercase tracking-wide text-slate-400">{title}</p>
+      <p className="mt-2 text-3xl font-semibold text-white">{value}</p>
+      <p className="mt-3 text-sm text-slate-400">{description}</p>
+    </div>
+  );
+}

--- a/lib/data/events.ts
+++ b/lib/data/events.ts
@@ -1,0 +1,65 @@
+import { EventRecord } from "../types";
+
+export const events: EventRecord[] = [
+  {
+    id: "aaaaaaa1-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
+    vesselId: "11111111-1111-1111-1111-111111111111",
+    eventDate: {
+      start: "2024-05-01T08:00:00Z",
+    },
+    location: {
+      latitude: 36.8508,
+      longitude: -76.2859,
+      locationName: "North Atlantic, east of Norfolk",
+    },
+    confidence: "High",
+    evidenceType: "Official Photo Release",
+    summary:
+      "USS Gerald R. Ford departed Norfolk with Carrier Strike Group 12 for exercises in the North Atlantic.",
+    sourceUrl: "https://www.navy.mil/Press-Office/News-Stories/",
+    sourceExcerpt:
+      "Carrier Strike Group 12 departed Naval Station Norfolk to conduct joint exercises with NATO partners.",
+    lastVerifiedAt: "2024-05-02T12:00:00Z",
+    createdAt: "2024-05-02T12:00:00Z",
+    updatedAt: "2024-05-02T12:00:00Z",
+  },
+  {
+    id: "aaaaaaa2-aaaa-aaaa-aaaa-aaaaaaaaaaa2",
+    vesselId: "22222222-2222-2222-2222-222222222222",
+    eventDate: {
+      start: "2024-04-18T00:00:00Z",
+      end: "2024-04-22T00:00:00Z",
+    },
+    location: {
+      latitude: 21.3069,
+      longitude: -157.8583,
+      locationName: "Honolulu, Hawaii",
+    },
+    confidence: "Medium",
+    evidenceType: "Media Report",
+    summary:
+      "Local media reported USS Nimitz conducting port visit in Pearl Harbor prior to Pacific deployment.",
+    sourceUrl: "https://news.usni.org/",
+    lastVerifiedAt: "2024-04-23T15:30:00Z",
+    createdAt: "2024-04-23T15:30:00Z",
+    updatedAt: "2024-04-23T15:30:00Z",
+  },
+  {
+    id: "aaaaaaa3-aaaa-aaaa-aaaa-aaaaaaaaaaa3",
+    vesselId: "33333333-3333-3333-3333-333333333333",
+    eventDate: {
+      start: "2024-03-28T00:00:00Z",
+    },
+    location: {
+      locationName: "Western Pacific (exact position undisclosed)",
+    },
+    confidence: "Low",
+    evidenceType: "OSINT Social Media",
+    summary:
+      "Multiple OSINT observers suggested Theodore Roosevelt transited the South China Sea; no official confirmation.",
+    sourceUrl: "https://twitter.com/",
+    lastVerifiedAt: "2024-04-01T10:00:00Z",
+    createdAt: "2024-04-01T10:00:00Z",
+    updatedAt: "2024-04-01T10:00:00Z",
+  },
+];

--- a/lib/data/review-logs.ts
+++ b/lib/data/review-logs.ts
@@ -1,0 +1,20 @@
+import { ReviewLog } from "../types";
+
+export const reviewLogs: ReviewLog[] = [
+  {
+    id: "bbbbbbb1-bbbb-bbbb-bbbb-bbbbbbbbbbb1",
+    eventId: "aaaaaaa1-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
+    reviewer: "Duty Officer",
+    reviewNotes: "Confirmed via official imagery and press release.",
+    confidenceAdjustment: "High",
+    createdAt: "2024-05-02T14:00:00Z",
+  },
+  {
+    id: "bbbbbbb2-bbbb-bbbb-bbbb-bbbbbbbbbbb2",
+    eventId: "aaaaaaa3-aaaa-aaaa-aaaa-aaaaaaaaaaa3",
+    reviewer: "Analyst",
+    reviewNotes: "Single-source OSINT, awaiting satellite confirmation.",
+    confidenceAdjustment: "Low",
+    createdAt: "2024-04-01T11:00:00Z",
+  },
+];

--- a/lib/data/stats.ts
+++ b/lib/data/stats.ts
@@ -1,0 +1,9 @@
+import { FleetStatistics } from "../types";
+
+export const fleetStats: FleetStatistics = {
+  totalVessels: 11,
+  activeDeployments: 4,
+  eventsLast30Days: 9,
+  vesselsMissingUpdates: 3,
+  generatedAt: new Date("2024-05-10T00:00:00Z").toISOString(),
+};

--- a/lib/data/vessels.ts
+++ b/lib/data/vessels.ts
@@ -1,0 +1,25 @@
+import { Vessel } from "../types";
+
+export const vessels: Vessel[] = [
+  {
+    id: "11111111-1111-1111-1111-111111111111",
+    name: "USS Gerald R. Ford",
+    hullNumber: "CVN-78",
+    vesselClass: "Ford-class",
+    homeport: "Naval Station Norfolk",
+  },
+  {
+    id: "22222222-2222-2222-2222-222222222222",
+    name: "USS Nimitz",
+    hullNumber: "CVN-68",
+    vesselClass: "Nimitz-class",
+    homeport: "Naval Base Kitsap",
+  },
+  {
+    id: "33333333-3333-3333-3333-333333333333",
+    name: "USS Theodore Roosevelt",
+    hullNumber: "CVN-71",
+    vesselClass: "Nimitz-class",
+    homeport: "Naval Base San Diego",
+  },
+];

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+
+export const confidenceSchema = z.enum(["High", "Medium", "Low"]);
+
+export const vesselSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  hullNumber: z.string(),
+  vesselClass: z.string(),
+  homeport: z.string().optional(),
+  image: z.string().url().optional(),
+});
+
+export const eventSchema = z.object({
+  id: z.string().uuid(),
+  vesselId: z.string().uuid(),
+  eventDate: z.object({
+    start: z.string().datetime(),
+    end: z.string().datetime().optional(),
+  }),
+  location: z.object({
+    latitude: z.number().min(-90).max(90).optional(),
+    longitude: z.number().min(-180).max(180).optional(),
+    locationName: z.string(),
+  }),
+  confidence: confidenceSchema,
+  evidenceType: z.string(),
+  summary: z.string(),
+  sourceUrl: z.string().url(),
+  sourceExcerpt: z.string().optional(),
+  lastVerifiedAt: z.string().datetime(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+export const reviewLogSchema = z.object({
+  id: z.string().uuid(),
+  eventId: z.string().uuid(),
+  reviewer: z.string(),
+  reviewNotes: z.string(),
+  confidenceAdjustment: confidenceSchema.optional(),
+  createdAt: z.string().datetime(),
+});
+
+export const statsSchema = z.object({
+  totalVessels: z.number().nonnegative(),
+  activeDeployments: z.number().nonnegative(),
+  eventsLast30Days: z.number().nonnegative(),
+  vesselsMissingUpdates: z.number().nonnegative(),
+  generatedAt: z.string().datetime(),
+});

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,51 @@
+export type ConfidenceLevel = "High" | "Medium" | "Low";
+
+export interface Vessel {
+  id: string;
+  name: string;
+  hullNumber: string;
+  vesselClass: string;
+  homeport?: string;
+  image?: string;
+}
+
+export interface EventLocation {
+  latitude?: number;
+  longitude?: number;
+  locationName: string;
+}
+
+export interface EventRecord {
+  id: string;
+  vesselId: string;
+  eventDate: {
+    start: string;
+    end?: string;
+  };
+  location: EventLocation;
+  confidence: ConfidenceLevel;
+  evidenceType: string;
+  summary: string;
+  sourceUrl: string;
+  sourceExcerpt?: string;
+  lastVerifiedAt: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ReviewLog {
+  id: string;
+  eventId: string;
+  reviewer: string;
+  reviewNotes: string;
+  confidenceAdjustment?: ConfidenceLevel;
+  createdAt: string;
+}
+
+export interface FleetStatistics {
+  totalVessels: number;
+  activeDeployments: number;
+  eventsLast30Days: number;
+  vesselsMissingUpdates: number;
+  generatedAt: string;
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,45 @@
+import { EventRecord } from "./types";
+
+export function getLatestEventsByVessel(events: EventRecord[]): Record<string, EventRecord> {
+  return events.reduce<Record<string, EventRecord>>((acc, event) => {
+    const existing = acc[event.vesselId];
+    if (!existing) {
+      acc[event.vesselId] = event;
+      return acc;
+    }
+
+    const existingDate = new Date(existing.lastVerifiedAt).getTime();
+    const currentDate = new Date(event.lastVerifiedAt).getTime();
+    if (currentDate > existingDate) {
+      acc[event.vesselId] = event;
+    }
+    return acc;
+  }, {});
+}
+
+export function getVesselEvents(events: EventRecord[], vesselId?: string): EventRecord[] {
+  if (!vesselId) {
+    return events;
+  }
+  return events.filter((event) => event.vesselId === vesselId);
+}
+
+export function formatDateRange(event: EventRecord): string {
+  const start = new Date(event.eventDate.start).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+
+  if (!event.eventDate.end) {
+    return start;
+  }
+
+  const end = new Date(event.eventDate.end).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+
+  return `${start} – ${end}`;
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,12 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    serverActions: {
+      bodySizeLimit: "2mb",
+    },
+  },
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "osint-carrier-tracker",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "zod": "3.22.4"
+  },
+  "devDependencies": {
+    "@tailwindcss/typography": "0.5.10",
+    "@types/node": "20.11.19",
+    "@types/react": "18.2.44",
+    "@types/react-dom": "18.2.18",
+    "autoprefixer": "10.4.16",
+    "eslint": "8.56.0",
+    "eslint-config-next": "14.2.3",
+    "postcss": "8.4.33",
+    "tailwindcss": "3.4.1",
+    "typescript": "5.3.3"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,28 @@
+import type { Config } from "tailwindcss";
+import typography from "@tailwindcss/typography";
+
+const config: Config = {
+  content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}", "./lib/**/*.{ts,tsx}"],
+  darkMode: "class",
+  theme: {
+    extend: {
+      colors: {
+        navy: {
+          50: "#f0f4ff",
+          100: "#d9e2ff",
+          200: "#b0c3ff",
+          300: "#809eff",
+          400: "#4f77f9",
+          500: "#2b53d6",
+          600: "#1b3dad",
+          700: "#142f85",
+          800: "#0e1f59",
+          900: "#091436"
+        },
+      },
+    },
+  },
+  plugins: [typography],
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "noEmit": true,
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- bootstrap a Next.js App Router skeleton with global layout, navigation, and supporting pages aligned to the DESIGN.md brief
- add mocked datasets, typed schemas, and dashboard components to preview map, timeline, and tabular OSINT intelligence experiences
- expose read-only API routes plus Tailwind/TypeScript/ESLint configuration to prepare for future Supabase integration

## Testing
- npm install *(fails: registry access returns 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca4ef49ef08330a2bcc528a400b321