### PR TITLE
Add CSV and GeoJSON export endpoints

### DIFF
--- a/app/api/export/csv/route.ts
+++ b/app/api/export/csv/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { events } from "@/lib/data/events";
+import { vessels } from "@/lib/data/vessels";
+import { eventsToCsv, ExportDataset, vesselsToCsv } from "@/lib/exporters";
+
+const CACHE_CONTROL = "public, max-age=3600, stale-while-revalidate=86400";
+
+function parseDataset(value: string | null): ExportDataset | null {
+  if (value === null) {
+    return "events";
+  }
+  if (value === "events" || value === "vessels") {
+    return value;
+  }
+  return null;
+}
+
+export async function GET(request: NextRequest) {
+  const dataset = parseDataset(request.nextUrl.searchParams.get("dataset"));
+
+  if (!dataset) {
+    return NextResponse.json({ error: "Invalid dataset. Use 'events' or 'vessels'." }, { status: 400 });
+  }
+
+  const body = dataset === "events" ? eventsToCsv(events, vessels) : vesselsToCsv(vessels);
+  const filename = `osint-${dataset}.csv`;
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Cache-Control": CACHE_CONTROL,
+      "Content-Disposition": `attachment; filename="${filename}"`,
+    },
+  });
+}

--- a/app/api/export/geojson/route.ts
+++ b/app/api/export/geojson/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { events } from "@/lib/data/events";
+import { vessels } from "@/lib/data/vessels";
+import { eventsToGeoJson, ExportDataset, vesselsToGeoJson } from "@/lib/exporters";
+
+const CACHE_CONTROL = "public, max-age=3600, stale-while-revalidate=86400";
+
+function parseDataset(value: string | null): ExportDataset | null {
+  if (value === null) {
+    return "events";
+  }
+  if (value === "events" || value === "vessels") {
+    return value;
+  }
+  return null;
+}
+
+export async function GET(request: NextRequest) {
+  const dataset = parseDataset(request.nextUrl.searchParams.get("dataset"));
+
+  if (!dataset) {
+    return NextResponse.json({ error: "Invalid dataset. Use 'events' or 'vessels'." }, { status: 400 });
+  }
+
+  const payload = dataset === "events" ? eventsToGeoJson(events, vessels) : vesselsToGeoJson(vessels);
+  const filename = `osint-${dataset}.geojson`;
+
+  return new Response(JSON.stringify(payload, null, 2), {
+    headers: {
+      "Content-Type": "application/geo+json; charset=utf-8",
+      "Cache-Control": CACHE_CONTROL,
+      "Content-Disposition": `attachment; filename="${filename}"`,
+    },
+  });
+}

--- a/app/data/page.tsx
+++ b/app/data/page.tsx
@@ -1,4 +1,5 @@
 import { EventTable } from "@/components/event-table";
+import { ExportControls } from "@/components/export-controls";
 import { events } from "@/lib/data/events";
 import { vessels } from "@/lib/data/vessels";
 
@@ -8,11 +9,18 @@ export default function DataPage() {
       <section className="rounded-xl border border-slate-800 bg-slate-950/70 p-6">
         <h1 className="text-2xl font-semibold text-white">Structured Data Explorer</h1>
         <p className="mt-2 text-sm text-slate-300">
-          Filterable tables and future CSV/GeoJSON export endpoints will live here. Data is curated from public reporting,
-          enriched with analyst annotations, and validated during build using schema checks.
+          Download sanitized exports for research workflows. Snapshots are rounded to 0.1° latitude/longitude to align with
+          our publication policy and include consistent field ordering for downstream ingestion.
         </p>
-        <div className="mt-4 rounded border border-slate-800 bg-slate-900/50 p-4 text-xs text-slate-400">
-          CSV &amp; GeoJSON download links will be exposed after the automated ingestion pipeline is connected to Supabase.
+        <div className="mt-4 rounded border border-slate-800 bg-slate-900/60 p-4">
+          <h2 className="text-sm font-semibold text-white">CSV &amp; GeoJSON exports</h2>
+          <p className="mt-2 text-xs text-slate-400">
+            Choose a dataset/format combination below. Downloads stream from the public API routes with caching enabled;
+            you&apos;ll see a status hint while the file is prepared and any errors will be surfaced inline.
+          </p>
+          <div className="mt-3">
+            <ExportControls />
+          </div>
         </div>
       </section>
       <EventTable events={events} vessels={vessels} />

--- a/components/export-controls.tsx
+++ b/components/export-controls.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+
+type Dataset = "events" | "vessels";
+type Format = "csv" | "geojson";
+
+type DownloadingState = {
+  dataset: Dataset;
+  format: Format;
+};
+
+const FORMAT_ENDPOINT: Record<Format, string> = {
+  csv: "/api/export/csv",
+  geojson: "/api/export/geojson",
+};
+
+const DATASET_LABEL: Record<Dataset, string> = {
+  events: "Event records",
+  vessels: "Vessel registry",
+};
+
+const FORMAT_LABEL: Record<Format, string> = {
+  csv: "CSV",
+  geojson: "GeoJSON",
+};
+
+function buildFilename(dataset: Dataset, format: Format) {
+  const extension = format === "csv" ? "csv" : "geojson";
+  return `osint-${dataset}.${extension}`;
+}
+
+export function ExportControls() {
+  const [downloading, setDownloading] = useState<DownloadingState | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const buttons = useMemo(() => {
+    const pairs: Array<{ dataset: Dataset; format: Format }> = [];
+    (Object.keys(DATASET_LABEL) as Dataset[]).forEach((dataset) => {
+      (Object.keys(FORMAT_ENDPOINT) as Format[]).forEach((format) => {
+        pairs.push({ dataset, format });
+      });
+    });
+    return pairs;
+  }, []);
+
+  const handleDownload = useCallback(async (dataset: Dataset, format: Format) => {
+    setError(null);
+    setDownloading({ dataset, format });
+
+    try {
+      const response = await fetch(`${FORMAT_ENDPOINT[format]}?dataset=${dataset}`);
+      if (!response.ok) {
+        throw new Error(`Export failed with status ${response.status}`);
+      }
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = buildFilename(dataset, format);
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error(err);
+      setError(`Unable to export ${DATASET_LABEL[dataset]} as ${FORMAT_LABEL[format]}. Please try again.`);
+    } finally {
+      setDownloading(null);
+    }
+  }, []);
+
+  return (
+    <div>
+      <div className="flex flex-wrap gap-2">
+        {buttons.map(({ dataset, format }) => {
+          const isActive = downloading?.dataset === dataset && downloading?.format === format;
+          const label = `${DATASET_LABEL[dataset]} (${FORMAT_LABEL[format]})`;
+          return (
+            <button
+              key={`${dataset}-${format}`}
+              type="button"
+              onClick={() => handleDownload(dataset, format)}
+              disabled={Boolean(downloading)}
+              aria-busy={isActive}
+              className="inline-flex items-center rounded-md border border-slate-700 bg-slate-900/70 px-3 py-2 text-xs font-medium text-slate-200 transition hover:border-navy-400 hover:text-white disabled:cursor-not-allowed disabled:opacity-70"
+            >
+              {isActive ? "Preparing download…" : label}
+            </button>
+          );
+        })}
+      </div>
+      {downloading && (
+        <p className="mt-2 text-xs text-slate-400">
+          Preparing {DATASET_LABEL[downloading.dataset]} {FORMAT_LABEL[downloading.format]} snapshot…
+        </p>
+      )}
+      {error && <p className="mt-2 text-xs text-rose-300">{error}</p>}
+    </div>
+  );
+}

--- a/lib/exporters.ts
+++ b/lib/exporters.ts
@@ -1,0 +1,195 @@
+import { EventRecord, Vessel } from "./types";
+
+export type ExportDataset = "events" | "vessels";
+
+type CsvValue = string | number | boolean | null | undefined;
+
+interface GeoJsonPoint {
+  type: "Point";
+  coordinates: [number, number];
+}
+
+interface GeoJsonFeature<P> {
+  type: "Feature";
+  geometry: GeoJsonPoint | null;
+  properties: P;
+}
+
+interface GeoJsonFeatureCollection<P> {
+  type: "FeatureCollection";
+  features: Array<GeoJsonFeature<P>>;
+}
+
+const EVENT_HEADERS = [
+  "id",
+  "vessel_id",
+  "vessel_name",
+  "hull_number",
+  "vessel_class",
+  "event_start",
+  "event_end",
+  "location_name",
+  "latitude",
+  "longitude",
+  "confidence",
+  "evidence_type",
+  "summary",
+  "source_url",
+  "source_excerpt",
+  "last_verified_at",
+  "created_at",
+  "updated_at",
+] as const;
+
+const VESSEL_HEADERS = [
+  "id",
+  "name",
+  "hull_number",
+  "vessel_class",
+  "homeport",
+  "image",
+] as const;
+
+function escapeCsvValue(value: CsvValue): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  const stringValue = String(value);
+  if (stringValue === "") {
+    return "";
+  }
+  const escaped = stringValue.replace(/"/g, '""');
+  return `"${escaped}"`;
+}
+
+function roundCoordinate(value: number | undefined): number | undefined {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return undefined;
+  }
+  return Math.round(value * 10) / 10;
+}
+
+export function eventsToCsv(events: EventRecord[], vessels: Vessel[]): string {
+  const vesselLookup = new Map(vessels.map((vessel) => [vessel.id, vessel]));
+  const headerRow = EVENT_HEADERS.join(",");
+  const rows = events.map((event) => {
+    const vessel = vesselLookup.get(event.vesselId);
+    const latitude = roundCoordinate(event.location.latitude);
+    const longitude = roundCoordinate(event.location.longitude);
+    const values: CsvValue[] = [
+      event.id,
+      event.vesselId,
+      vessel?.name ?? null,
+      vessel?.hullNumber ?? null,
+      vessel?.vesselClass ?? null,
+      event.eventDate.start,
+      event.eventDate.end ?? null,
+      event.location.locationName,
+      latitude !== undefined ? latitude.toFixed(1) : null,
+      longitude !== undefined ? longitude.toFixed(1) : null,
+      event.confidence,
+      event.evidenceType,
+      event.summary,
+      event.sourceUrl,
+      event.sourceExcerpt ?? null,
+      event.lastVerifiedAt,
+      event.createdAt,
+      event.updatedAt,
+    ];
+    return values.map(escapeCsvValue).join(",");
+  });
+
+  return [headerRow, ...rows].join("\n");
+}
+
+export function vesselsToCsv(vessels: Vessel[]): string {
+  const headerRow = VESSEL_HEADERS.join(",");
+  const rows = vessels.map((vessel) => {
+    const values: CsvValue[] = [
+      vessel.id,
+      vessel.name,
+      vessel.hullNumber,
+      vessel.vesselClass,
+      vessel.homeport ?? null,
+      vessel.image ?? null,
+    ];
+    return values.map(escapeCsvValue).join(",");
+  });
+
+  return [headerRow, ...rows].join("\n");
+}
+
+export function eventsToGeoJson(
+  events: EventRecord[],
+  vessels: Vessel[],
+): GeoJsonFeatureCollection<Record<(typeof EVENT_HEADERS)[number], string | number | null>> {
+  const vesselLookup = new Map(vessels.map((vessel) => [vessel.id, vessel]));
+
+  const features = events.map((event): GeoJsonFeature<Record<(typeof EVENT_HEADERS)[number], string | number | null>> => {
+    const vessel = vesselLookup.get(event.vesselId);
+    const latitude = roundCoordinate(event.location.latitude);
+    const longitude = roundCoordinate(event.location.longitude);
+    const geometry: GeoJsonPoint | null =
+      latitude !== undefined && longitude !== undefined
+        ? { type: "Point", coordinates: [longitude, latitude] as [number, number] }
+        : null;
+
+    const properties: Record<(typeof EVENT_HEADERS)[number], string | number | null> = {
+      id: event.id,
+      vessel_id: event.vesselId,
+      vessel_name: vessel?.name ?? null,
+      hull_number: vessel?.hullNumber ?? null,
+      vessel_class: vessel?.vesselClass ?? null,
+      event_start: event.eventDate.start,
+      event_end: event.eventDate.end ?? null,
+      location_name: event.location.locationName,
+      latitude: latitude ?? null,
+      longitude: longitude ?? null,
+      confidence: event.confidence,
+      evidence_type: event.evidenceType,
+      summary: event.summary,
+      source_url: event.sourceUrl,
+      source_excerpt: event.sourceExcerpt ?? null,
+      last_verified_at: event.lastVerifiedAt,
+      created_at: event.createdAt,
+      updated_at: event.updatedAt,
+    };
+
+    return {
+      type: "Feature",
+      geometry,
+      properties,
+    };
+  });
+
+  return {
+    type: "FeatureCollection",
+    features,
+  };
+}
+
+export function vesselsToGeoJson(
+  vessels: Vessel[],
+): GeoJsonFeatureCollection<{ [K in (typeof VESSEL_HEADERS)[number]]: string | null }> {
+  const features = vessels.map((vessel): GeoJsonFeature<{ [K in (typeof VESSEL_HEADERS)[number]]: string | null }> => {
+    const properties: { [K in (typeof VESSEL_HEADERS)[number]]: string | null } = {
+      id: vessel.id,
+      name: vessel.name,
+      hull_number: vessel.hullNumber,
+      vessel_class: vessel.vesselClass,
+      homeport: vessel.homeport ?? null,
+      image: vessel.image ?? null,
+    };
+
+    return {
+      type: "Feature",
+      geometry: null,
+      properties,
+    };
+  });
+
+  return {
+    type: "FeatureCollection",
+    features,
+  };
+}


### PR DESCRIPTION
## Summary
- add reusable export helpers that normalize CSV headers and GeoJSON precision
- expose cached CSV/GeoJSON API routes that reuse the exporters for both datasets
- surface download controls on the data explorer and document the export contract

## Testing
- npm run lint *(fails: Next.js CLI does not support next.config.ts in this repo)*
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68ca639c7cc48330a0b4385f14efc102